### PR TITLE
Fixed typo for invalid command "fprime-util install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ and will produce a binary that can be run on the user's system. This is accompli
 will run the code next, we will also run the install command to ensure we may easily find the binaries.
 
 ```
-fprime-util install
+fprime-util build
 ```
 
 ## Running the F´ Ground System and Code


### PR DESCRIPTION
The procedure described in the README.MD includes a typo when it is requested to write the command :

```
$fprime-util install
```

When we enter it we get the following error:
```
usage: fprime-util [-h] {generate,purge,hash-to-file,info,build,impl,check} ...
fprime-util: error: argument command: invalid choice: 'install' (choose from 'generate', 'purge', 'hash-to-file', 'info', 'build', 'impl', 'check')
```
It must be replaced by:

```
$fprime-util build
```
as it is described in the text of the procedure above: "This is accomplished by using the `build` subcommand of `fprime-util`"
